### PR TITLE
Add vuetur to the list of syntax highlighters

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Language packages extend the editor with syntax highlighting and/or snippets for
 - [Stylus](https://marketplace.visualstudio.com/items?itemName=sysoev.language-stylus)
 - [Swift](https://marketplace.visualstudio.com/items?itemName=Kasik96.swift)
 - [VEX](https://marketplace.visualstudio.com/items?itemName=melmass.vex)
+- [Vue.js](https://marketplace.visualstudio.com/items?itemName=octref.vetur)
 - [Zephir](https://marketplace.visualstudio.com/items?itemName=zephir-lang.zephir)
 
 # Editor Keymaps


### PR DESCRIPTION
## Name of an extension you are adding
Vuetur.

## Why do you think this extension is awesome?
Vueture allows vscode to properly format the syntax of single file
*.vue components. It also povides some intellisense to the codebase

...

## Make sure that:

[ ] Screenshot/GIF included (to demonstrate the plugin functionality)

[ ] ToC updated
